### PR TITLE
Corrects original_data  when MLR fails

### DIFF
--- a/interpolation/inverse_distance_3d.pyx
+++ b/interpolation/inverse_distance_3d.pyx
@@ -86,7 +86,7 @@ def inverse_distance_3d(residues: Dict[str, Dict[str, float]],
 cdef float point_residue(double x, double y, double z, double[:] xpos, double[:] ypos, double[:] zpos, double[:] values, int N):
     cdef int power = 2
     cdef int smoothing = 0
-    cdef int penalization = 100
+    cdef int penalization = 40
     cdef double numerator = 0
     cdef int i
     cdef double dist_3d

--- a/interpolation/inverse_distance_3d.pyx
+++ b/interpolation/inverse_distance_3d.pyx
@@ -98,12 +98,10 @@ cdef float point_residue(double x, double y, double z, double[:] xpos, double[:]
             y - ypos[i]) ** 2)
 
         if dist < 0.00000000001:
-            print('asdadsadasdasd')
             return values[i]
         
         dist_3d = sqrt(dist ** 2 + (penalization * (z - zpos[i])) ** 2 + smoothing*smoothing)
-        #print('dist:' + str(dist))
-        #print('3dist:' + str(dist_3d))
+
         numerator = numerator + (values[i] / pow(dist_3d, power))
         denominator = denominator + (1 / pow(dist_3d, power))
 

--- a/pymica/clustered_regression.py
+++ b/pymica/clustered_regression.py
@@ -2,8 +2,10 @@
 and takes the best option for each zone
 '''
 import sys
+from copy import deepcopy
 
 import ogr
+
 from pymica.multiregression import MultiRegressionSigma
 
 
@@ -64,8 +66,9 @@ class ClusteredRegression:
                         cluster_file_regressions.append(cluster_regression)
                         file_mse += (mse_cluster * len(data_in_cluster))
                     else:
-                        regr_all.original_data = cluster_regression.original_data
-                        cluster_file_regressions.append(regr_all)
+                        new_regr_all = deepcopy(regr_all)
+                        new_regr_all.original_data = data_in_cluster
+                        cluster_file_regressions.append(new_regr_all)
                         file_mse += mse_all * len(data_in_cluster)
 
                 file_mse = file_mse / len(data)

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ import subprocess
 import numpy
 import setuptools
 
-release = subprocess.check_output(
-    ['git', 'describe', '--abbrev=0', '--tags']).decode('utf-8').strip()
+release = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags']).decode('utf-8').strip()
 version = ".".join(release.split('.')[0:2])
 name = "pymica"
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ import subprocess
 import numpy
 import setuptools
 
-release = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags']).decode('utf-8').strip()
+release = subprocess.check_output(
+    ['git', 'describe', '--abbrev=0', '--tags']).decode('utf-8').strip()
 version = ".".join(release.split('.')[0:2])
 name = "pymica"
 
@@ -27,9 +28,12 @@ else:
     ext_extention = 'pyx'
 
 ext_modules = [Extension("interpolation.inverse_distance",
-                         ['interpolation/inverse_distance.' + ext_extention], include_dirs=[numpy.get_include()]),
+                         ['interpolation/inverse_distance.' + ext_extention],
+                         include_dirs=[numpy.get_include()]),
                Extension("interpolation.inverse_distance_3d",
-                         ['interpolation/inverse_distance_3d.' + ext_extention], include_dirs=[numpy.get_include()])]
+                         ['interpolation/inverse_distance_3d.'
+                          + ext_extention],
+                         include_dirs=[numpy.get_include()])]
 
 for e in ext_modules:
     e.cython_directives = {"embedsignature": True}


### PR DESCRIPTION
Wrong behaviour detected: When MLR fails in a cluster regression, the original_data doesn't update and takes the previous one. 

Correction: The original_data is updated properly using deepcopy to avoid parameters overwriting.