### PR TITLE
Dealing with shared stations in different clusters

### DIFF
--- a/pymica/clustered_regression.py
+++ b/pymica/clustered_regression.py
@@ -34,7 +34,12 @@ class ClusteredRegression:
                                         x_vars=self.data_format['x_vars'])
         residuals_all = regr_all.get_residuals()
 
-        self.mse = __get_residuals_mse__(residuals_all)
+        # Workaround for cases when different clusters share the same
+        # station. The mse calculated as
+        #       self.mse = __get_residuals_mse__(residuals_all),
+        # does not correspond to the mse when stations are in more
+        # than one cluster.
+        self.mse = sys.float_info.max
 
         self.final_regr = [regr_all]
         self.final_data = [data]

--- a/pymica/pymica.py
+++ b/pymica/pymica.py
@@ -125,17 +125,17 @@ class PyMica:
         if clusters:
             cl_reg = ClusteredRegression(data, clusters['clusters_files'],
                                          data_format=self.data_format)
-
             cluster_file_index = clusters['clusters_files'].index(
-                cl_reg.final_cluster_file)
+                    cl_reg.final_cluster_file)
 
             d_s = gdal.Open(clusters['mask_files'][cluster_file_index])
             mask = d_s.ReadAsArray()
             d_s = None
 
-            out_data = apply_clustered_regression(cl_reg, self.variables,
-                                                  self.data_format['x_vars'],
-                                                  mask)
+            out_data = apply_clustered_regression(
+                                cl_reg, self.variables,
+                                self.data_format['x_vars'],
+                                mask)
         else:
             cl_reg = MultiRegressionSigma(data,
                                           id_key=self.data_format['id_key'],


### PR DESCRIPTION
When a station is in more than one cluster, the mse calculated ordinarily fails to capture de proper error. 

Since applying clusters never worsen the general mse (worst of the cases, the error is the same), the initial mse is set to a maximum value. Then, a cluster file is always selected.